### PR TITLE
Fix for #2 "Can't find generator"

### DIFF
--- a/lib/generators/uuid_it_generator.rb
+++ b/lib/generators/uuid_it_generator.rb
@@ -4,9 +4,10 @@ require 'rails/generators/migration'
 class UuidItGenerator < Rails::Generators::Base
   include Rails::Generators::Migration
 
+  source_root File.expand_path('../../../generators/uuid_it/templates', __FILE__)
+
   def copy_files(*args)
-    migration_template File.join(File.dirname(__FILE__), "..", "..", "generators", "uuid_it", "templates", "create_uuids.rb"),
-                                 "db/migrate/create_uuids.rb"
+    migration_template "create_uuids.rb", "db/migrate/create_uuids.rb"
   end
 
   def self.next_migration_number dirname


### PR DESCRIPTION
[Issue #2](https://github.com/aduffeck/uuid_it/issues/2) is still valid for Rails 3.2, despite being closed without explanation.

Using `source_root`, now generates successfully with Rails 3.2/Ruby 1.9.3.

Adapted from [this patch](https://github.com/spraints/friendly_id/commit/a84a9bcb67f5a47ee9dcc19720e3267cfe7ccab5) of a similar issue.
